### PR TITLE
Add documentation to ConfigStore

### DIFF
--- a/rconfig/ConfigStore.py
+++ b/rconfig/ConfigStore.py
@@ -1,3 +1,10 @@
+"""Store and inspect configuration class references.
+
+This module provides :class:`ConfigReference`, a dataclass capturing the
+constructor parameters of a target class, and :class:`ConfigStore`, a singleton
+registry for such references.
+"""
+
 import inspect
 from collections import OrderedDict
 from dataclasses import dataclass, field
@@ -10,14 +17,22 @@ from .util import Singleton
 
 @dataclass(kw_only=True, frozen=True)
 class ConfigReference:
+    """Immutable reference to a configuration class.
+
+    The ``decisive_init_parameters`` attribute exposes the parameters required
+    to instantiate the referenced class.
+    """
+
     name: str
     target_class: type[Any]
     decisive_init_parameters: MappingProxyType[str, Parameter] = field(init=False, repr=True, compare=False)
 
     def __post_init__(self) -> None:
+        """Populate ``decisive_init_parameters`` after initialization."""
         self._determine_decisive_init_parameters()
 
     def _determine_decisive_init_parameters(self) -> None:
+        """Inspect the target class and cache its constructor parameters."""
         self._validate_target_has_init_method()
 
         init_signature = inspect.signature(self.target_class.__init__, follow_wrapped=True)
@@ -25,7 +40,8 @@ class ConfigReference:
 
         object.__setattr__(self, "decisive_init_parameters", MappingProxyType(init_parameters))
 
-    def _validate_target_has_init_method(self):
+    def _validate_target_has_init_method(self) -> None:
+        """Ensure the target class defines an ``__init__`` method."""
         if not hasattr(self.target_class, '__init__'):
             message = (f"The class '{self.target_class.__module__}.{self.target_class.__qualname__}' "
                        f"has no '__init__' method.")
@@ -34,7 +50,10 @@ class ConfigReference:
 
 @Singleton
 class ConfigStore:
+    """Registry for :class:`ConfigReference` objects."""
+
     def __init__(self) -> None:
+        """Initialize the store."""
         self._known_references: dict[str, ConfigReference] = {}
 
     def register(
@@ -42,6 +61,11 @@ class ConfigStore:
             name: str,
             target: Type[Any],
     ) -> None:
+        """Register a target class under a unique name.
+
+        :param name: Identifier for the target class.
+        :param target: Class to register.
+        """
         reference = ConfigReference(
             name=name,
             target_class=target,
@@ -50,4 +74,5 @@ class ConfigStore:
 
     @property
     def known_references(self) -> MappingProxyType[str, ConfigReference]:
+        """Read-only mapping of all registered configuration references."""
         return MappingProxyType(self._known_references)


### PR DESCRIPTION
## Summary
- document configuration reference and store utilities
- annotate registration and lookup mechanisms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6890d8aa27688323b576fb6826b949b8